### PR TITLE
feat: Add admin endpoint to retrieve all products, including deleted …

### DIFF
--- a/src/modules/products/products.controller.ts
+++ b/src/modules/products/products.controller.ts
@@ -25,6 +25,11 @@ export class ProductsController {
     return this.productsService.findAll();
   }
 
+  @Get('/admin')
+  findAllWithDeleted() {
+    return this.productsService.findAll(true);
+  }
+
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.productsService.findOne(id);

--- a/src/modules/products/products.service.ts
+++ b/src/modules/products/products.service.ts
@@ -1,10 +1,13 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { CreateProductDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Product } from './entities/product.entity';
-import { UpdateResult } from 'typeorm';
 import { Course } from '../courses/entities/course.entity';
 import { Module } from '../modules/entities/module.entity';
 import { Content } from '../contents/entities/content.entity';
@@ -39,23 +42,23 @@ export class ProductsService {
       let entity = null;
       switch (polymorphicEntityType) {
         case 'course':
-          entity = await this.courseRepository.findOneBy({
-            id: polymorphicEntityId,
+          entity = await this.courseRepository.findOne({
+            where: { id: polymorphicEntityId },
           });
           break;
         case 'module':
-          entity = await this.moduleRepository.findOneBy({
-            id: polymorphicEntityId,
+          entity = await this.moduleRepository.findOne({
+            where: { id: polymorphicEntityId },
           });
           break;
         case 'lesson':
-          entity = await this.lessonRepository.findOneBy({
-            id: polymorphicEntityId,
+          entity = await this.lessonRepository.findOne({
+            where: { id: polymorphicEntityId },
           });
           break;
         case 'content':
-          entity = await this.contentRepository.findOneBy({
-            id: polymorphicEntityId,
+          entity = await this.contentRepository.findOne({
+            where: { id: polymorphicEntityId },
           });
           break;
       }
@@ -70,12 +73,15 @@ export class ProductsService {
     return this.productRepository.save(newProduct);
   }
 
-  async findAll(): Promise<Product[]> {
-    return await this.productRepository.find();
+  async findAll(withDeleted: boolean = false): Promise<Product[]> {
+    return await this.productRepository.find({ withDeleted });
   }
 
-  async findOne(id: string): Promise<Product> {
-    const product = await this.productRepository.findOneBy({ id });
+  async findOne(id: string, withDeleted: boolean = false): Promise<Product> {
+    const product = await this.productRepository.findOne({
+      where: { id },
+      withDeleted,
+    });
 
     if (!product) {
       throw new NotFoundException(`Product not found`);
@@ -87,28 +93,40 @@ export class ProductsService {
   async update(
     id: string,
     updateProductDto: UpdateProductDto,
-  ): Promise<UpdateResult> {
-    const product = await this.productRepository.findOneBy({ id });
+  ): Promise<{ id: string }> {
+    const product = await this.productRepository.findOne({ where: { id } });
 
     if (!product) {
       throw new NotFoundException(`Product not found`);
     }
 
-    return await this.productRepository.update(id, {
-      ...product,
-      ...updateProductDto,
-    });
+    const updatedProduct = await this.productRepository.update(
+      id,
+      updateProductDto,
+    );
+
+    if (updatedProduct.affected <= 0) {
+      throw new InternalServerErrorException(`Product not updated`);
+    }
+
+    return { id };
   }
 
-  async remove(id: string): Promise<UpdateResult> {
-    const product = this.productRepository.findOneBy({ id });
+  async remove(id: string): Promise<{ id: string }> {
+    const product = this.productRepository.findOne({ where: { id } });
 
     if (!product) {
       throw new NotFoundException(`Product not found`);
     }
 
-    return await this.productRepository.update(id, {
+    const deletedProduct = await this.productRepository.update(id, {
       deleted_at: new Date(),
     });
+
+    if (deletedProduct.affected <= 0) {
+      throw new InternalServerErrorException(`Product not deleted`);
+    }
+
+    return { id };
   }
 }


### PR DESCRIPTION
This PR adds a new endpoint `/admin` to the `ProductsController` that allows retrieving all products, including the deleted ones. It also updates the `findAll` method in the `ProductsService` to accept an optional parameter `withDeleted` to control whether to include deleted products in the result.