### PR TITLE
Update Lesson Entity, CreateLessonDto, and LessonsService

### DIFF
--- a/src/modules/lessons/dto/create-lesson.dto.ts
+++ b/src/modules/lessons/dto/create-lesson.dto.ts
@@ -1,6 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsNumber, IsString, IsUUID } from 'class-validator';
 export class CreateLessonDto {
+  @ApiProperty({
+    example: 'Lesson 1',
+    description: 'The title of the lesson',
+  })
+  title: string;
+
   @IsNotEmpty()
   @IsString()
   @IsUUID()

--- a/src/modules/lessons/entities/lesson.entity.ts
+++ b/src/modules/lessons/entities/lesson.entity.ts
@@ -11,17 +11,27 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { v4 as uuid } from 'uuid';
 
 @Entity()
 export class Lesson {
   @PrimaryGeneratedColumn('uuid')
-  id: string;
+  id: string = uuid();
+
+  @Column()
+  title: string;
 
   @Column()
   order: number;
 
   @Column({ default: 0 })
   xp: number;
+
+  @Column({ default: 0 })
+  coins: number;
+
+  @Column({ unique: true })
+  slug: string;
 
   @ManyToOne(() => Module)
   @JoinColumn({ name: 'module_id' })


### PR DESCRIPTION
In Lesson Entity:
- Added a 'title' field to store the title of the lesson.
- Added a 'coins' field to store the number of coins associated with the lesson.
- Added a 'slug' field to store a unique slug for the lesson.

In CreateLessonDto:
- Added a 'title' property to specify the title of the lesson.

In LessonsService:
- Updated the 'createLesson' method to include generating a slug for the lesson based on the title.
- Updated the 'updateLesson' method to regenerate the slug if the title is updated.