### PR TITLE
feat: Add support for multipart/form-data in CoursesController create and update methods

### DIFF
--- a/src/modules/courses/courses.controller.ts
+++ b/src/modules/courses/courses.controller.ts
@@ -13,7 +13,7 @@ import {
 import { CoursesService } from './courses.service';
 import { CreateCourseDto } from './dto/create-course.dto';
 import { UpdateCourseDto } from './dto/update-course.dto';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiConsumes, ApiTags } from '@nestjs/swagger';
 import { FileFieldsInterceptor } from '@nestjs/platform-express';
 
 @ApiTags('Courses')
@@ -44,6 +44,25 @@ export class CoursesController {
     ),
   )
   @Post()
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        courseImg: {
+          type: 'string',
+          format: 'binary',
+        },
+        courseBgImg: {
+          type: 'string',
+          format: 'binary',
+        },
+        title: { type: 'string' },
+        headline: { type: 'string' },
+        description: { type: 'string' },
+      },
+    },
+  })
   create(
     @UploadedFiles()
     files: {
@@ -93,6 +112,25 @@ export class CoursesController {
     ),
   )
   @Put(':id')
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        courseImg: {
+          type: 'string',
+          format: 'binary',
+        },
+        courseBgImg: {
+          type: 'string',
+          format: 'binary',
+        },
+        title: { type: 'string' },
+        headline: { type: 'string' },
+        description: { type: 'string' },
+      },
+    },
+  })
   update(
     @UploadedFiles()
     files: {


### PR DESCRIPTION
The CoursesController create and update methods have been updated to support multipart/form-data requests. This allows for file uploads of course images. The request body now includes properties for courseImg, courseBgImg, title, headline, and description. The courseImg and courseBgImg properties are of type 'string' with the format 'binary', allowing for binary file uploads. This enhancement improves the functionality of the Courses module.