### PR TITLE
feat: Update CoursesController and CoursesService to handle optional course images

### DIFF
--- a/src/modules/courses/courses.controller.ts
+++ b/src/modules/courses/courses.controller.ts
@@ -66,8 +66,8 @@ export class CoursesController {
   create(
     @UploadedFiles()
     files: {
-      courseImg?: Express.Multer.File[];
-      courseBgImg?: Express.Multer.File[];
+      courseImg: Express.Multer.File[];
+      courseBgImg: Express.Multer.File[];
     },
     @Body() createCourseDto: CreateCourseDto,
   ) {
@@ -134,8 +134,8 @@ export class CoursesController {
   update(
     @UploadedFiles()
     files: {
-      courseImg: Express.Multer.File[];
-      courseBgImg: Express.Multer.File[];
+      courseImg?: Express.Multer.File[];
+      courseBgImg?: Express.Multer.File[];
     } = null,
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateCourseDto: UpdateCourseDto,

--- a/src/modules/courses/courses.service.ts
+++ b/src/modules/courses/courses.service.ts
@@ -95,8 +95,8 @@ export class CoursesService {
     id: string,
     updateCourseDto: UpdateCourseDto,
     files: {
-      courseImg: Express.Multer.File[];
-      courseBgImg: Express.Multer.File[];
+      courseImg?: Express.Multer.File[];
+      courseBgImg?: Express.Multer.File[];
     } | null,
   ) {
     try {


### PR DESCRIPTION
The CoursesController and CoursesService have been updated to handle optional course images. The 'courseImg' and 'courseBgImg' properties in the request payload are now optional, allowing for cases where no images need to be uploaded. This enhancement provides flexibility in managing course images.