### PR TITLE
feat: Update LessonsService to load relation IDs in findOne method and ModulesService not to load relation IDs in update method

### DIFF
--- a/src/modules/lessons/lessons.service.ts
+++ b/src/modules/lessons/lessons.service.ts
@@ -127,7 +127,10 @@ export class LessonsService {
         throw new InternalServerErrorException('Lesson not updated');
       }
 
-      return await this.lessonsRepository.findOne({ where: { id } });
+      return await this.lessonsRepository.findOne({
+        where: { id },
+        loadRelationIds: true,
+      });
     }
   }
 

--- a/src/modules/modules/modules.service.ts
+++ b/src/modules/modules/modules.service.ts
@@ -74,7 +74,6 @@ export class ModulesService {
   async updateModule(id: string, updateModuleDto: UpdateModuleDto) {
     const foundModule = await this.moduleRepository.findOne({
       where: { id },
-      loadRelationIds: true,
     });
 
     if (!foundModule) {


### PR DESCRIPTION
The LessonsService has been updated to include the `loadRelationIds` option in the `findOne` method of the `lessonsRepository`. This allows for loading the relation IDs along with the lesson data, improving the efficiency of retrieving related data.