### PR TITLE
refactor: Update LessonsService and ModulesService to load relation IDs in findOne method

### DIFF
--- a/src/modules/lessons/lessons.service.ts
+++ b/src/modules/lessons/lessons.service.ts
@@ -29,7 +29,15 @@ export class LessonsService {
   async getLessonById(id: string) {
     const lesson = await this.lessonsRepository.findOne({
       where: { id },
-      loadRelationIds: true,
+      select: {
+        module: {
+          id: true,
+          course: {
+            id: true,
+          },
+        },
+      },
+      relations: ['module', 'module.course'],
     });
     if (!lesson) {
       throw new NotFoundException('Lesson not found');
@@ -54,8 +62,6 @@ export class LessonsService {
       if (orderExists) {
         throw new ConflictException('Lesson order already exists');
       }
-
-      console.log(createLessonDto.title);
 
       const slug = `${slugify(createLessonDto.title, {
         lower: true,

--- a/src/modules/modules/modules.service.ts
+++ b/src/modules/modules/modules.service.ts
@@ -73,8 +73,11 @@ export class ModulesService {
           id: true,
           title: true,
         },
+        course: {
+          id: true,
+        },
       },
-      relations: ['lessons'],
+      relations: ['lessons', 'course'],
     });
     if (!moduleExists) {
       throw new NotFoundException('Module not found');


### PR DESCRIPTION
The LessonsService and ModulesService have been refactored to include the `loadRelationIds` option in the `findOne` method of their respective repositories. This allows for loading the relation IDs along with the lesson and module data, improving the efficiency of retrieving related data.