### PR TITLE
feat: Update LessonsService to load relation IDs in getAllLessons method

### DIFF
--- a/src/modules/lessons/lessons.service.ts
+++ b/src/modules/lessons/lessons.service.ts
@@ -21,8 +21,19 @@ export class LessonsService {
 
   async getAllLessons(withDeleted: boolean = false) {
     return await this.lessonsRepository.find({
-      loadRelationIds: true,
       withDeleted,
+      select: {
+        module: {
+          id: true,
+          course: {
+            id: true,
+          },
+        },
+        contents: {
+          id: true,
+        },
+      },
+      relations: ['module', 'module.course', 'contents'],
     });
   }
 
@@ -36,8 +47,9 @@ export class LessonsService {
             id: true,
           },
         },
+        contents: true,
       },
-      relations: ['module', 'module.course'],
+      relations: ['module', 'module.course', 'contents'],
     });
     if (!lesson) {
       throw new NotFoundException('Lesson not found');


### PR DESCRIPTION
The LessonsService has been updated to include the `select` and `relations` options in the `getAllLessons` method of the `lessonsRepository`. This allows for loading the necessary relation IDs along with the lesson data, improving the efficiency of retrieving related data.