### PR TITLE
refactor: Enable automatic migration execution and add slug field to Category entity

### DIFF
--- a/src/config/typeorm.ts
+++ b/src/config/typeorm.ts
@@ -17,7 +17,7 @@ const config = {
   logging: true,
   synchronize: false,
   dropSchema: false,
-  /*  migrationsRun: true, */ // Habilitar la ejecución automática de migraciones al iniciar la aplicación
+  migrationsRun: true, // Habilitar la ejecución automática de migraciones al iniciar la aplicación
 };
 
 export default registerAs('typeorm', () => config);

--- a/src/migrations/1715785868077-add_slug_column_to_categories_table.ts
+++ b/src/migrations/1715785868077-add_slug_column_to_categories_table.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddSlugColumnToCategoriesTable1715785868077 implements MigrationInterface {
+    name = 'AddSlugColumnToCategoriesTable1715785868077'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "categories" ADD "slug" character varying NOT NULL DEFAULT 'programacion'`);
+        await queryRunner.query(`ALTER TABLE "categories" ADD CONSTRAINT "UQ_8b0be371d28245da6e4f4b61878" UNIQUE ("name")`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "categories" DROP CONSTRAINT "UQ_8b0be371d28245da6e4f4b61878"`);
+        await queryRunner.query(`ALTER TABLE "categories" DROP COLUMN "slug"`);
+    }
+
+}

--- a/src/modules/categories/categories.service.ts
+++ b/src/modules/categories/categories.service.ts
@@ -1,9 +1,15 @@
-import { BadRequestException, ConflictException, Injectable, NotFoundException } from "@nestjs/common";
-import { CreateCategoryDto } from "./dto/create-category.dto";
-import { UpdateCategoryDto } from "./dto/update-category.dto";
-import { InjectRepository } from "@nestjs/typeorm";
-import { Category } from "./entities/category.entity";
-import { Repository } from "typeorm";
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Category } from './entities/category.entity';
+import { Repository } from 'typeorm';
+import slugify from 'slugify';
 
 @Injectable()
 export class CategoriesService {
@@ -15,61 +21,88 @@ export class CategoriesService {
   async findAll() {
     const foundCategories = await this.categoriesRepository.find();
     if (foundCategories.length === 0) {
-      throw new NotFoundException("There are no categories to display");
+      throw new NotFoundException('There are no categories to display');
     }
     return foundCategories;
   }
-  
+
   async findById(id: string) {
     try {
       const foundCategory = await this.categoriesRepository.findOne({
         where: { id },
       });
       if (!foundCategory) {
-        throw new NotFoundException("Category not found");
+        throw new NotFoundException('Category not found');
       }
       return foundCategory;
-    } catch (error : any) {
+    } catch (error: any) {
       throw new BadRequestException(error.message);
     }
   }
-  
+
   async create(createCategoryDto: CreateCategoryDto) {
     try {
       const foundCategory = await this.categoriesRepository.findOne({
         where: { name: createCategoryDto.name },
       });
+
       if (foundCategory) {
-        throw new ConflictException("Category already exists");
+        throw new ConflictException('Category already exists');
       }
+
+      const slug = `${slugify(createCategoryDto.name, {
+        lower: true,
+        replacement: '-',
+        locale: 'en',
+      })}-${new Date().getTime()}`;
+
       const newCategory = this.categoriesRepository.create({
         name: createCategoryDto.name,
+        slug,
       });
+
       const savedCategory = await this.categoriesRepository.save(newCategory);
+
       return savedCategory;
-    } catch (error : any) {
+    } catch (error: any) {
       throw new BadRequestException(error.message);
     }
   }
-  
+
   async update(id: string, updateCategoryDto: UpdateCategoryDto) {
     try {
       const foundCategory = await this.categoriesRepository.findOne({
         where: { id },
       });
+
       if (!foundCategory) {
-        throw new NotFoundException("Category not found");
+        throw new NotFoundException('Category not found');
       }
-      await this.categoriesRepository.update(id, updateCategoryDto);
+
+      if (updateCategoryDto.name) {
+        const slug = `${slugify(updateCategoryDto.name, {
+          lower: true,
+          replacement: '-',
+          locale: 'en',
+        })}-${new Date().getTime()}`;
+        foundCategory.slug = slug;
+      }
+
+      await this.categoriesRepository.update(id, {
+        ...foundCategory,
+        ...updateCategoryDto,
+      });
+
       const updatedCategory = await this.categoriesRepository.findOne({
         where: { id },
       });
+
       return updatedCategory;
-    } catch (error : any) {
+    } catch (error: any) {
       throw new BadRequestException(error.message);
     }
   }
-  
+
   async remove(id: string) {
     try {
       const foundCategory = await this.categoriesRepository.findOne({

--- a/src/modules/categories/dto/update-category.dto.ts
+++ b/src/modules/categories/dto/update-category.dto.ts
@@ -1,15 +1,4 @@
-import { ApiProperty } from "@nestjs/swagger";
-import { IsOptional, IsString, MaxLength, MinLength } from "class-validator";
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateCategoryDto } from './create-category.dto';
 
-export class UpdateCategoryDto {
-    @ApiProperty({
-        example: "Programacion",
-        description: "Use to change the category name",
-      })
-    @IsString()
-    @IsOptional()
-    @MaxLength(50)
-    @MinLength(10)
-    name: string
-
-}
+export class UpdateCategoryDto extends PartialType(CreateCategoryDto) {}

--- a/src/modules/categories/entities/category.entity.ts
+++ b/src/modules/categories/entities/category.entity.ts
@@ -7,16 +7,21 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   DeleteDateColumn,
+  Unique,
 } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 @Entity({ name: 'categories' })
+@Unique(['name'])
 export class Category {
   @PrimaryGeneratedColumn('uuid')
   id: string = uuid();
 
   @Column()
   name: string;
+
+  @Column({ default: 'programacion' })
+  slug: string;
 
   @ManyToMany(() => Course, (course) => course.categories)
   courses: Course[];

--- a/src/modules/courses/courses.service.ts
+++ b/src/modules/courses/courses.service.ts
@@ -32,8 +32,12 @@ export class CoursesService {
               title: true,
             },
           },
+          categories: {
+            id: true,
+            name: true,
+          },
         },
-        relations: ['modules', 'modules.lessons'],
+        relations: ['modules', 'modules.lessons', 'categories'],
       });
 
       return allCourses;
@@ -55,8 +59,12 @@ export class CoursesService {
               title: true,
             },
           },
+          categories: {
+            id: true,
+            name: true,
+          },
         },
-        relations: ['modules', 'modules.lessons'],
+        relations: ['modules', 'modules.lessons', 'categories'],
       });
       if (!foundedCourse) throw new NotFoundException('Course not found');
       return foundedCourse;


### PR DESCRIPTION
The `typeorm` configuration has been updated to enable the automatic execution of migrations when the application starts. Additionally, a new `slug` field has been added to the `Category` entity to store a URL-friendly version of the category name.